### PR TITLE
服务端给客户端推送消息的时候允许直接传对象，而不需要先转成json字符

### DIFF
--- a/api/send2client/send2client.go
+++ b/api/send2client/send2client.go
@@ -16,7 +16,7 @@ type inputData struct {
 	SendUserId string `json:"sendUserId"`
 	Code       int    `json:"code"`
 	Msg        string `json:"msg"`
-	Data       string `json:"data"`
+	Data       interface{} `json:"data"`
 }
 
 func (c *Controller) Run(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
服务端给客户端推送消息的时候允许直接传对象，而不需要先转成json字符